### PR TITLE
Fixed parsing of headers containing locale string with an underscore …

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,7 +6,7 @@ Release History
 0.1.2 (unreleased)
 ++++++++++++++++++
 
-- Nothing changed yet.
+- Fixed parsing of headers containing locale string with an underscore in it, such as "en_GB".
 
 
 0.1.1 (2017-08-10)

--- a/src/accept_language/accept_language.py
+++ b/src/accept_language/accept_language.py
@@ -46,7 +46,7 @@ def parse_accept_language(accept_language_str, default_quality=None):
             lang_code, quality_value = accept_lang_segment.split(';')
             quality_value = float(QUALITY_VAL_SUB_REGEX.sub('', quality_value))
 
-        lang_code_components = lang_code.split('-')
+        lang_code_components = re.split('-|_', lang_code)
         if not all(VALIDATE_LANG_REGEX.match(c) for c in lang_code_components):
             continue
 

--- a/src/tests/test_accept_language.py
+++ b/src/tests/test_accept_language.py
@@ -5,6 +5,7 @@ from accept_language import Lang, parse_accept_language, MAX_HEADER_LEN
 
 @pytest.mark.parametrize('header_string, exp_result', [
     ('en-US', [Lang(locale='en_US', language='en', quality=1.0)]),
+    ('en_US', [Lang(locale='en_US', language='en', quality=1.0)]),
     ('es', [Lang(locale=None, language='es', quality=1.0)]),
     (
         'es-mx;q=0.8,es,en',


### PR DESCRIPTION
…in it, such as "en_GB".